### PR TITLE
Two fixes for cross-browser support

### DIFF
--- a/WebAssembly/src/CsoundAudioNode.js
+++ b/WebAssembly/src/CsoundAudioNode.js
@@ -293,22 +293,24 @@ class CsoundAudioNode extends AudioWorkletNode {
             this.message_callback("WebAudio frames per second:         " +  this.context.sampleRate + "\n");
             this.message_callback("WebAudio maximum output channels:   " +  this.context.destination.maxChannelCount + "\n");
             this.connect(this.context.destination);
-            let midi_access = await navigator.requestMIDIAccess();
-            const inputs = midi_access.inputs.values();
-            var post_message = this.postMessage;
-            for (let entry of midi_access.inputs) {
-                var port_ = entry[1];
-                message_callback_("MIDI port: type: " + port_.type + "  manufacturer: " + port_.manufacturer + " name: " + port_.name +
+            if (navigator.requestMIDIAccess) {
+              let midi_access = await navigator.requestMIDIAccess();
+              const inputs = midi_access.inputs.values();
+              var post_message = this.postMessage;
+              for (let entry of midi_access.inputs) {
+                  var port_ = entry[1];
+                  message_callback_("MIDI port: type: " + port_.type + "  manufacturer: " + port_.manufacturer + " name: " + port_.name +
+                      " version: " + port_.version + "\n");
+                  // Using the MessagePort for this is probably not good enough.
+                  port_.onmidimessage = function(event) {
+                      post_message(["MidiEvent", event.data[0], event.data[1], event.data[2]]);
+                  };
+              }
+              for (let entry of midi_access.outputs) {
+                  var port_ = entry[1];
+                  message_callback_( "MIDI port: type: " + port_.type + " manufacturer: " + port_.manufacturer + " name: " + port_.name +
                     " version: " + port_.version + "\n");
-                // Using the MessagePort for this is probably not good enough.
-                port_.onmidimessage = function(event) {
-                    post_message(["MidiEvent", event.data[0], event.data[1], event.data[2]]);
-                };
-            }
-            for (let entry of midi_access.outputs) {
-                var port_ = entry[1];
-                message_callback_( "MIDI port: type: " + port_.type + " manufacturer: " + port_.manufacturer + " name: " + port_.name +
-                  " version: " + port_.version + "\n");
+              }
             }
             // Try to obtain the Web browser audio input, if available.
             // Not to be confused with any other audio input interfaces on the 

--- a/WebAssembly/src/CsoundAudioProcessor_postjs.js
+++ b/WebAssembly/src/CsoundAudioProcessor_postjs.js
@@ -327,11 +327,11 @@ class CsoundAudioProcessor extends AudioWorkletProcessor {
                 }
             }
             this.format_validated = true;
-            // These loops require Csound's ksmps to equal the length of the 
-            // WebAudio input and output buffers (should ALWAYS be 128).
-            if (this.has_audio_input === true) {
+            // These loops require Csound's ksmps to equal the length of the
+            // WebAudio input and output buffers (always 128 frames if present).
+            if (this.has_audio_input === true && inputChannelN != 0) {
                 // WebAudio spreads 1 input channel across 2 channels...
-                for (let inputChannelI = 0; inputChannelI < this.inputChannelN; inputChannelI++) {
+                for (let inputChannelI = 0; inputChannelI < inputChannelN; inputChannelI++) {
                     let inputChannelBuffer = inputBuffer[inputChannelI];
                     for (let sampleFrameI = 0; sampleFrameI < hostFrameN; sampleFrameI++) {
                         this.spinBuffer[(sampleFrameI * inputChannelN) + inputChannelI] = (inputChannelBuffer[sampleFrameI] * this.zerodBFS);


### PR DESCRIPTION
Hi, I'm one of the audio developers of Firefox. We're releasing `AudioWorklet` in Firefox 76, and I'm excited to see Csound on the web.

I got send the demo page, and it errored out in Firefox. The biggest issue was on our end (a memory limit issue, triggered by the fact that Csound is being loaded via an array literal it seems, I can help changing this to dramatically reduce the memory footprint/size of the page if that would be of interest).

There was two other bugs:
- Firefox doesn't implement Web MIDI (we have lots of code written for it, but it's not finished), so `navigator.requestMIDIAccess` isn't available. Simply skipping those lines in this case make it work, but still allows Chrome to use MIDI input
- There is no guarantee that audio input buffers are available, even if a connection with a `MediaStreamAudioSourceNode`. Audio input devices can take some time to open, etc., depending on the hardware/OS/etc.

I've written a patch for each of those issues.

I can also help answering question or anything you'd need, if it would help (in particular your interrogation about the number of audio input channels, just a few lines below my fix).

With [our bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1631713) about the memory limit fixed, and those two patches applied to your code, it works great!